### PR TITLE
Ignore `window.Vue` in ES2015 Environments

### DIFF
--- a/src/vue-custom-element.js
+++ b/src/vue-custom-element.js
@@ -2,6 +2,7 @@ import registerCustomElement from './utils/registerCustomElement';
 import createVueInstance from './utils/createVueInstance';
 import { getProps, convertAttributeValue } from './utils/props';
 import { camelize } from './utils/helpers';
+import isES2015 from './utils/isES2015';
 
 function install(Vue) {
   Vue.customElement = function vueCustomElement(tag, componentDefinition, options = {}) {
@@ -76,6 +77,6 @@ function install(Vue) {
 
 export default install;
 
-if (typeof window !== 'undefined' && window.Vue) {
+if (typeof window !== 'undefined' && window.Vue && !isES2015) {
   window.Vue.use(install);
 }


### PR DESCRIPTION
I'm not sure if this will apply to everyone; in fact, it could possibly break many installations. However, it seems to reason that if `isES2015 == true`, since assets are being compiled in webpack or rollup, there is no reason for this library to search for a global instance of Vue.

This fixes #12.