### PR TITLE
Add TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,29 @@
+// Type definitions for vue-custom-element 1.2.1
+// Definitions by: Isaac Lyman http://isaaclyman.com
+
+import Vue from "vue"
+import { ComponentOptions, PluginFunction } from 'vue'
+
+declare class VueCustomElement {
+    static install: PluginFunction<never>;
+}
+
+declare namespace VueCustomElement {
+    interface options {
+        constructorCallback: () => void;
+        connectedCallback: () => void;
+        disconnectedCallback: () => void;
+        attributeChangedCallback: (name: string, oldValue: any, value: any) => void;
+        destroyTimeout: number;
+        props: ComponentOptions<Vue>['props'];
+        shadow: boolean;
+        shadowCss: string;
+    }
+}
+
+declare module "vue" {
+    export function customElement(tag: string, componentDefinition: ComponentOptions<Vue>, options?: VueCustomElement.options): void;
+    export function customElement(tag: string, asyncComponentDefinition: () => Promise<ComponentOptions<Vue>>, options?: VueCustomElement.options): void;
+}
+
+export = VueCustomElement

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Custom Elements for Vue.js",
   "main": "dist/vue-custom-element.js",
   "module": "dist/vue-custom-element.esm.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/karol-f/vue-custom-element"


### PR DESCRIPTION
This tiny type definition file will make it possible to use vue-custom-element in a TypeScript application without casting the Vue global to `<any>`.