### PR TITLE
Enable passing in object props even before components are attached to DOM

### DIFF
--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -104,10 +104,16 @@ export function getPropsData(element, componentDefinition, props) {
   const propsData = componentDefinition.propsData || {};
 
   props.hyphenate.forEach((name, index) => {
-    const value = element.attributes[name] && element.attributes[name].nodeValue;
+    const elementAttribute = element.attributes[name];
+    const propCamelCase = props.camelCase[index];
 
-    if (value !== undefined && value !== '') {
-      propsData[props.camelCase[index]] = convertAttributeValue(value);
+    if (typeof elementAttribute === 'object' && !(elementAttribute instanceof Attr)) {
+      propsData[propCamelCase] = elementAttribute;
+      return;
+    }
+
+    if (elementAttribute instanceof Attr && elementAttribute.value) {
+      propsData[propCamelCase] = convertAttributeValue(elementAttribute.value);
     }
   });
 


### PR DESCRIPTION
changed the way the initial prop value being passed in before the component gets attached into DOM. So that an object value can be passed into a component from very beginning.