### PR TITLE
Add .prop v-bind support to vue-custom-element

### DIFF
--- a/demo/components/DemoBasic-component.vue
+++ b/demo/components/DemoBasic-component.vue
@@ -37,7 +37,9 @@
       'prop1',
       'prop2',
       'prop3',
-      'longPropName'
+      'longPropName',
+      'objectProp',
+      'arrayProp'
     ],
     data() {
       return {
@@ -62,6 +64,14 @@
           prop: 'long-prop-name',
           value: JSON.stringify(this.longPropName),
           type: typeof this.longPropName
+        }, {
+          prop: 'objectProp',
+          value: this.objectProp,
+          type: typeof this.objectProp
+        }, {
+          prop: 'arrayProp',
+          value: this.arrayProp,
+          type: typeof this.arrayProp
         }];
       }
     },

--- a/demo/components/DemoBinding-component.vue
+++ b/demo/components/DemoBinding-component.vue
@@ -32,22 +32,60 @@
       </div>
     </div>
 
+    <div class="el-form-item">
+      <label class="el-form-item__label">object-prop</label>
+      <div class="el-form-item__content">{{objectProp}}</div>
+      <a class="button white" @click="addProperty(objectProp)">Add Property</a>
+    </div>
+
+    <div class="el-form-item">
+      <label class="el-form-item__label">array-prop</label>
+      <div class="el-form-item__content">{{arrayProp}}</div>
+      <a class="button white" @click="addElement(arrayProp)">Add Element</a>
+    </div>
+
     <br />
 
-    <demo-basic :prop1="prop1" :prop2="prop2" :prop3="prop3 || 'false'" :long-prop-name="longPropName"></demo-basic>
+    <demo-basic :prop1="prop1" :prop2="prop2" :prop3="prop3 || 'false'" :long-prop-name="longPropName" :object-prop.prop="objectProp" :array-prop.prop="arrayProp"></demo-basic>
   </div>
 </template>
 
 <script>
+  import Vue from 'vue';
+
   export default {
     data() {
       return {
         prop1: 1,
         prop2: 'example text',
         prop3: true,
-        longPropName: 'long name'
+        longPropName: 'long name',
+        objectProp: { foo: 'bar' },
+        arrayProp: [1, 2, 3]
       };
+    },
+    methods: {
+      addProperty(object) {
+        const keys = Object.keys(object);
+        Vue.set(object, `property_${keys.length}`, keys.length);
+      },
+      addElement(array) {
+        array.push(array.length + 1);
+      }
     }
   };
 </script>
+
+<style>
+a.button.white {
+  width: 140px;
+  height: 30px;
+  border-radius: 8px;
+  font-size: 0.8em;
+  padding: 4px;
+  text-align: center;
+  cursor: pointer;
+}
+</style>
+
 

--- a/demo/components/DemoBinding-docs.vue
+++ b/demo/components/DemoBinding-docs.vue
@@ -48,12 +48,15 @@
     :prop1="prop1"
     :prop2="prop2"
     :prop3="prop3"
-    :long-prop-name="longPropName">
+    :long-prop-name="longPropName"
+    :object-prop.prop="objectProp"
+    :array-prop.prop="arrayProp">
   </demo-basic>`
         ),
         plainJavaScript: (
 `document.getElementsByTagName('demo-basic')[0].prop1 = 123
 document.getElementsByTagName('demo-basic')[0].prop2 = 'Text from JavaScript'
+document.getElementsByTagName('demo-basic')[0].objectProp = {foo: 'baz'}
 `
         )
       };

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -104,13 +104,13 @@ export function getPropsData(element, componentDefinition, props) {
   const propsData = componentDefinition.propsData || {};
 
   props.hyphenate.forEach((name, index) => {
-    const elementAttribute = element.attributes[name];
     const propCamelCase = props.camelCase[index];
+    const propValue = element.attributes[name] || element[propCamelCase];
 
-    if (typeof elementAttribute === 'object' && !(elementAttribute instanceof Attr)) {
-      propsData[propCamelCase] = elementAttribute;
-    } else if (elementAttribute instanceof Attr && elementAttribute.value) {
-      propsData[propCamelCase] = convertAttributeValue(elementAttribute.value);
+    if (typeof propValue === 'object' && !(propValue instanceof Attr)) {
+      propsData[propCamelCase] = propValue;
+    } else if (propValue instanceof Attr && propValue.value) {
+      propsData[propCamelCase] = convertAttributeValue(propValue.value);
     }
   });
 


### PR DESCRIPTION
**Rationale:**
I have been looking for a technique for passing objects and arrays to vue-custom-element components. Vue components allow for this type of communication, passing data by property by default.
After reading up on some of the other [closed issues](https://github.com/karol-f/vue-custom-element/issues/5) in the repository, I was ready to give up. However, I found that Vue JS and Angular both support passing data to CustomElements by property. In Vue, this is achieved by using the '.prop' v-bind modifier. Supporting this modifier in vue-custom-element would allow developers to pass data to custom elements with near-same syntax (v-bind:foo="myObject" vs. v-bind:foo.prop="myObject").

In addition to the code change, I've made some changes to the binding example to demonstrate passing objects and arrays by property. Let me know if you'd like me to go a bit further or provide more elaborate examples in the documentation.

**Commit Message:**
By default, Vue allows the user to specify the method by which developers pass props (attribute or property). When encountering a custom element, Vue passes all props by attribute by default. This is not a good solution for rich data like objects and arrays. Vue, Angular, and other major frameworks provide a method to specify binding rich data to a component. For Vue, this is the '.prop' modifier.
https://vuejs.org/v2/api/#v-bind
The changes in this commit build in support for passing this rich data by checking for a passed-by-property prop if no matching attribute exists.