### PR TITLE
Add Support For Prop Validation Types

### DIFF
--- a/demo/components/DemoBasic-component.vue
+++ b/demo/components/DemoBasic-component.vue
@@ -33,14 +33,17 @@
 
 <script>
   export default {
-    props: [
-      'prop1',
-      'prop2',
-      'prop3',
-      'longPropName',
-      'objectProp',
-      'arrayProp'
-    ],
+    props: {
+      prop1: {},
+      prop2: {},
+      prop3: {},
+      stringProp: {
+        type: String
+      },
+      longPropName: {},
+      objectProp: {},
+      arrayProp: {}
+    },
     data() {
       return {
         message: 'Hello Vue-custom-element!'
@@ -60,6 +63,10 @@
           prop: 'prop3',
           value: JSON.stringify(this.prop3),
           type: typeof this.prop3
+        }, {
+          prop: 'stringProp',
+          value: this.stringProp,
+          type: typeof this.stringProp
         }, {
           prop: 'long-prop-name',
           value: JSON.stringify(this.longPropName),

--- a/demo/components/DemoBinding-component.vue
+++ b/demo/components/DemoBinding-component.vue
@@ -26,6 +26,13 @@
     </div>
 
     <div class="el-form-item">
+      <label class="el-form-item__label">string-prop</label>
+      <div class="el-form-item__content">
+        <el-input v-model="stringProp" size="small"></el-input>
+      </div>
+    </div>
+
+    <div class="el-form-item">
       <label class="el-form-item__label">long-prop-name</label>
       <div class="el-form-item__content">
         <el-input v-model="longPropName" size="small"></el-input>
@@ -50,7 +57,7 @@
 
     <br />
 
-    <demo-basic :prop1="prop1" :prop2="prop2" :prop3="prop3 || 'false'" :long-prop-name="longPropName" :object-prop.prop="objectProp" :array-prop.prop="arrayProp"></demo-basic>
+    <demo-basic :prop1="prop1" :prop2="prop2" :prop3="prop3 || 'false'" :string-prop="stringProp" :long-prop-name="longPropName" :object-prop.prop="objectProp" :array-prop.prop="arrayProp"></demo-basic>
   </div>
 </template>
 
@@ -63,6 +70,7 @@
         prop1: 1,
         prop2: 'example text',
         prop3: true,
+        stringProp: '12',
         longPropName: 'long name',
         objectProp: { foo: 'bar' },
         arrayProp: [1, 2, 3]

--- a/demo/components/DemoBinding-docs.vue
+++ b/demo/components/DemoBinding-docs.vue
@@ -48,6 +48,7 @@
     :prop1="prop1"
     :prop2="prop2"
     :prop3="prop3"
+    :string-prop="12"
     :long-prop-name="longPropName"
     :object-prop.prop="objectProp"
     :array-prop.prop="arrayProp">
@@ -56,8 +57,8 @@
         plainJavaScript: (
 `document.getElementsByTagName('demo-basic')[0].prop1 = 123
 document.getElementsByTagName('demo-basic')[0].prop2 = 'Text from JavaScript'
-document.getElementsByTagName('demo-basic')[0].objectProp = {foo: 'baz'}
-`
+document.getElementsByTagName('demo-basic')[0].stringProp = '123'
+document.getElementsByTagName('demo-basic')[0].objectProp = {foo: 'baz'}`
         )
       };
     },

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -3,16 +3,20 @@ import { camelize, hyphenate } from './helpers';
 /**
  * Number and Boolean props are treated as strings
  * We should convert it so props will behave as intended
+ * Conversion can be overwritted by prop validation (https://vuejs.org/v2/guide/components-props.html#Prop-Validation)
  * @param value
+ * @param overrideType
  * @returns {*}
  */
-export function convertAttributeValue(value) {
+export function convertAttributeValue(value, overrideType) {
   let propsValue = value;
   const isBoolean = ['true', 'false'].indexOf(value) > -1;
   const valueParsed = parseFloat(propsValue, 10);
   const isNumber = !isNaN(valueParsed) && isFinite(propsValue) && !propsValue.match(/^0+[^.]\d*$/g);
 
-  if (isBoolean) {
+  if (overrideType) {
+    propsValue = overrideType(value);
+  } else if (isBoolean) {
     propsValue = propsValue === 'true';
   } else if (isNumber) {
     propsValue = valueParsed;
@@ -69,6 +73,20 @@ export function getProps(componentDefinition = {}) {
 }
 
 /**
+ * Maps typeof operator back to the associated type
+ * @param type
+ */
+export function mapToType(type) {
+  switch (type.toLowerCase()) {
+    case 'boolean': return Boolean;
+    case 'number': return Number;
+    case 'string': return String;
+    case 'symbol': return Symbol;
+    default: return null;
+  }
+}
+
+/**
  * If we get DOM node of element we could use it like this:
  * document.querySelector('widget-vue1').prop1 <-- get prop
  * document.querySelector('widget-vue1').prop1 = 'new Value' <-- set prop
@@ -87,7 +105,8 @@ export function reactiveProps(element, props) {
           const propName = props.camelCase[index];
           this.__vue_custom_element__[propName] = value;
         } else {
-          this.setAttribute(props.hyphenate[index], convertAttributeValue(value));
+          const type = mapToType(typeof props.hyphenate[index]);
+          this.setAttribute(props.hyphenate[index], convertAttributeValue(value, type));
         }
       }
     });
@@ -107,8 +126,16 @@ export function getPropsData(element, componentDefinition, props) {
     const propCamelCase = props.camelCase[index];
     const propValue = element.attributes[name] || element[propCamelCase];
 
+    let type = null;
+    if (componentDefinition.props &&
+        componentDefinition.props[propCamelCase] &&
+        componentDefinition.props[propCamelCase].type
+    ) {
+      type = componentDefinition.props[propCamelCase].type;
+    }
+
     propsData[propCamelCase] = propValue instanceof Attr
-      ? convertAttributeValue(propValue.value)
+      ? convertAttributeValue(propValue.value, type)
       : propValue;
   });
 

--- a/src/vue-custom-element.js
+++ b/src/vue-custom-element.js
@@ -1,6 +1,6 @@
 import registerCustomElement from './utils/registerCustomElement';
 import createVueInstance from './utils/createVueInstance';
-import { getProps, convertAttributeValue } from './utils/props';
+import { getProps, convertAttributeValue, mapToType } from './utils/props';
 import { camelize } from './utils/helpers';
 
 function install(Vue) {
@@ -63,7 +63,8 @@ function install(Vue) {
         if (this.__vue_custom_element__ && typeof value !== 'undefined') {
           const nameCamelCase = camelize(name);
           typeof options.attributeChangedCallback === 'function' && options.attributeChangedCallback.call(this, name, oldValue, value);
-          this.__vue_custom_element__[nameCamelCase] = convertAttributeValue(value);
+          const oldType = mapToType(typeof oldValue);
+          this.__vue_custom_element__[nameCamelCase] = convertAttributeValue(value, oldType);
         }
       },
 


### PR DESCRIPTION
__Rationale:__
I'm proposing an enhancement to vue-custom-element in response to [this opened issue](https://github.com/karol-f/vue-custom-element/issues/96), which demonstrates automatic prop type conversion behavior which violates the vue component definition's prop validation options. The goal of the change is to bring the vue-custom-element functionality more in-line with that of vanilla Vue components.

__Design:__
The approach I took to this change was to add an enhancement to the `convertAttributeValue` function, adding an optional argument which, if present, would cast the value to the desired Global type object (String, Number, Boolean, etc...). When the component is created this type comes from the component definition's [prop validations](https://vuejs.org/v2/guide/components-props.html#Prop-Validation) if they exist. For all future modifications to the prop value, the type is preserved. Much of this functionality is found in `props.js`.

In addition to the core functionality change, I've made changes to the binding example, passing `'12'` to stringProp and verifying that 12 can change value but remains a string by using the [String global object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String). 

__Commit Message:__
Props defined with an object and type property will have their chosen type respected, even if the prop is changed reactively.