### PR TITLE
Correct boolean inconsistency during prop validation type conversion.

### DIFF
--- a/demo/components/DemoBasic-component.vue
+++ b/demo/components/DemoBasic-component.vue
@@ -40,6 +40,12 @@
       stringProp: {
         type: String
       },
+      booleanProp: {
+        type: Boolean
+      },
+      numberProp: {
+        type: Number
+      },
       longPropName: {},
       objectProp: {},
       arrayProp: {}
@@ -67,6 +73,14 @@
           prop: 'stringProp (type: String)',
           value: this.stringProp,
           type: typeof this.stringProp
+        }, {
+          prop: 'booleanProp (type: Boolean)',
+          value: this.booleanProp,
+          type: typeof this.booleanProp
+        }, {
+          prop: 'numberProp (type: Number)',
+          value: this.numberProp,
+          type: typeof this.numberProp
         }, {
           prop: 'long-prop-name',
           value: JSON.stringify(this.longPropName),

--- a/demo/components/DemoBinding-component.vue
+++ b/demo/components/DemoBinding-component.vue
@@ -33,6 +33,20 @@
     </div>
 
     <div class="el-form-item">
+      <label class="el-form-item__label">boolean-prop</label>
+      <div class="el-form-item__content">
+        <el-input v-model="booleanProp" size="small"></el-input>
+      </div>
+    </div>
+
+    <div class="el-form-item">
+      <label class="el-form-item__label">number-prop</label>
+      <div class="el-form-item__content">
+        <el-input v-model="numberProp" size="small"></el-input>
+      </div>
+    </div>
+
+    <div class="el-form-item">
       <label class="el-form-item__label">long-prop-name</label>
       <div class="el-form-item__content">
         <el-input v-model="longPropName" size="small"></el-input>
@@ -57,7 +71,17 @@
 
     <br />
 
-    <demo-basic :prop1="prop1" :prop2="prop2" :prop3="prop3 || 'false'" :string-prop="stringProp" :long-prop-name="longPropName" :object-prop.prop="objectProp" :array-prop.prop="arrayProp"></demo-basic>
+    <demo-basic
+      :prop1="prop1"
+      :prop2="prop2"
+      :prop3="prop3 || 'false'"
+      :string-prop="stringProp"
+      :boolean-prop="booleanProp"
+      :number-prop="numberProp"
+      :long-prop-name="longPropName"
+      :object-prop.prop="objectProp"
+      :array-prop.prop="arrayProp"
+    ></demo-basic>
   </div>
 </template>
 
@@ -71,6 +95,8 @@
         prop2: 'example text',
         prop3: true,
         stringProp: '12',
+        booleanProp: 'true',
+        numberProp: 42,
         longPropName: 'long name',
         objectProp: { foo: 'bar' },
         arrayProp: [1, 2, 3]

--- a/src/utils/props.js
+++ b/src/utils/props.js
@@ -14,9 +14,9 @@ export function convertAttributeValue(value, overrideType) {
   const valueParsed = parseFloat(propsValue, 10);
   const isNumber = !isNaN(valueParsed) && isFinite(propsValue) && !propsValue.match(/^0+[^.]\d*$/g);
 
-  if (overrideType) {
+  if (overrideType && overrideType !== Boolean) {
     propsValue = overrideType(value);
-  } else if (isBoolean) {
+  } else if (isBoolean || overrideType === Boolean) {
     propsValue = propsValue === 'true';
   } else if (isNumber) {
     propsValue = valueParsed;


### PR DESCRIPTION
I recently created an issue whereby Booleans were not being intuitively cast during prop validation type conversion.
https://github.com/karol-f/vue-custom-element/issues/103

As posted in the issue, here's an example of the prop validation side effect using vue-custom-element 3.0.0:
https://codepen.io/auzmartist/pen/jxOebb?editors=1010

This new code change makes a minimal change to the props.js `convertAttributeValue` function. It converts Boolean props with prop validation via the same means as boolean props without prop validation instead of the old way, which produces some unintuitive results:

```javascript
Boolean('true') // true
Boolean('false') // true
```

I've tested this via the demo examples, which I've modified to exhibit the fixed behavior.