### PR TITLE
made all options in options interface optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,23 +10,23 @@ declare class VueCustomElement {
 
 declare namespace VueCustomElement {
     interface options {
-        constructorCallback: () => void;
-        connectedCallback: () => void;
-        disconnectedCallback: () => void;
-        attributeChangedCallback: (name: string, oldValue: any, value: any) => void;
-        destroyTimeout: number;
-        props: ComponentOptions<Vue>['props'];
-        shadow: boolean;
-        shadowCss: string;
+        constructorCallback?: () => void;
+        connectedCallback?: () => void;
+        disconnectedCallback?: () => void;
+        attributeChangedCallback?: (name: string, oldValue: any, value: any) => void;
+        destroyTimeout?: number;
+        props?: ComponentOptions<Vue>['props'];
+        shadow?: boolean;
+        shadowCss?: string;
     }
 }
 
 declare module 'vue/types/vue' {
-  export interface VueConstructor {
-    customElement(tag: string, componentDefinition: ComponentOptions<Vue>, options?: VueCustomElement.options): void;
-    customElement(tag: string, singleFileComponent: VueConstructor<Vue>, options?: VueCustomElement.options): void;
-    customElement(tag: string, asyncComponentDefinition: () => Promise<ComponentOptions<Vue>>, options?: VueCustomElement.options): void;
-  }
+    export interface VueConstructor {
+        customElement(tag: string, componentDefinition: ComponentOptions<Vue>, options?: VueCustomElement.options): void;
+        customElement(tag: string, singleFileComponent: VueConstructor<Vue>, options?: VueCustomElement.options): void;
+        customElement(tag: string, asyncComponentDefinition: () => Promise<ComponentOptions<Vue>>, options?: VueCustomElement.options): void;
+    }
 }
 
 export default VueCustomElement


### PR DESCRIPTION
Issue #114 

For Typescript, the error is generating because options argument in Vue.customElement() requires all the options that are defined, but we are giving only shadow.

So, I made the all options optional.