### PR TITLE
Fix hardcoding selenium .jar file for nightwatch tests

### DIFF
--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -1,5 +1,6 @@
 require('babel-register')
 var config = require('../../config')
+var seleniumJar = require('shelljs').find('node_modules/selenium-server/lib/runner').filter(function(file){ return file.match(/selenium-server-standalone-.*\.jar$/); });
 
 // http://nightwatchjs.org/guide#settings-file
 module.exports = {
@@ -8,7 +9,7 @@ module.exports = {
 
   selenium: {
     start_process: true,
-    server_path: 'node_modules/selenium-server/lib/runner/selenium-server-standalone-3.3.0.jar',
+    server_path: seleniumJar,
     host: '127.0.0.1',
     port: 4444,
     cli_args: {


### PR DESCRIPTION
This fixes the error of having the wrong version of .jar when pulling down and testing on the clean master branch. Currently the version is selenium-server-standalone-3.14.0.jar per the package.json current semver.