### PR TITLE
fix: comp is destroyed when used in dynamic comp which is kept alive

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ declare namespace VueCustomElement {
         disconnectedCallback?: () => void;
         attributeChangedCallback?: (name: string, oldValue: any, value: any) => void;
         destroyTimeout?: number;
+        destroyOnDetach?: boolean;
         props?: ComponentOptions<Vue>['props'];
         shadow?: boolean;
         shadowCss?: string;

--- a/src/utils/registerCustomElement.js
+++ b/src/utils/registerCustomElement.js
@@ -4,6 +4,11 @@ import isES2015 from './isES2015';
 export default function registerCustomElement(tag, options = {}) {
   if (typeof customElements === 'undefined') { return; } // eslint-disable-line
 
+  // eslint-disable-next-line eqeqeq
+  if (options.destroyOnDetach == undefined) {
+    options.destroyOnDetach = true;
+  }
+
   function constructorCallback() {
     if (options.shadow === true && HTMLElement.prototype.attachShadow) {
       this.attachShadow({ mode: 'open' });

--- a/src/vue-custom-element.js
+++ b/src/vue-custom-element.js
@@ -48,13 +48,15 @@ function install(Vue) {
         this.__detached__ = true;
         typeof options.disconnectedCallback === 'function' && options.disconnectedCallback.call(this);
 
-        setTimeout(() => {
-          if (this.__detached__ && this.__vue_custom_element__) {
-            this.__vue_custom_element__.$destroy(true);
-            delete this.__vue_custom_element__;
-            delete this.__vue_custom_element_props__;
-          }
-        }, options.destroyTimeout || 3000);
+        if (options.destroyOnDetach) {
+          setTimeout(() => {
+            if (this.__detached__ && this.__vue_custom_element__) {
+              this.__vue_custom_element__.$destroy(true);
+              delete this.__vue_custom_element__;
+              delete this.__vue_custom_element_props__;
+            }
+          }, options.destroyTimeout || 3000);
+        }
       },
 
       /**


### PR DESCRIPTION
Providing destroyOnDetach option (default true) which will be checked to see if component should be destroyed or not when removed from DOM

For more info look #164