### PR TITLE
feat: return root instance if not mounted

### DIFF
--- a/src/utils/createVueInstance.js
+++ b/src/utils/createVueInstance.js
@@ -99,7 +99,10 @@ export default function createVueInstance(element, Vue, componentDefinition, pro
     // Define the Vue constructor to manage the element
     element.__vue_custom_element__ = new Vue(rootElement);
     element.__vue_custom_element_props__ = props;
-    element.getVueInstance = () => element.__vue_custom_element__.$children[0];
+    element.getVueInstance = () => {
+      const vueInstance = element.__vue_custom_element__;
+      return vueInstance.$children.length ? vueInstance.$children[0] : vueInstance;
+    };
 
     if (options.shadow && options.shadowCss && element.shadowRoot) {
       const style = document.createElement('style');


### PR DESCRIPTION
This pr supports delayed mounting of the Vue app by returning the root Vue instance in `getVueInstance` if no children exists yet

This makes the following possible:
```js
let customElementRoot
...
  beforeCreateVueInstance(root) {
    customElementRoot = root.el
    delete root.el
    return root
  },
  vueInstanceCreatedCallback() {
    const app = this.getVueInstance()
    // do some stuff with the vue instance
    app.$mount(customElementRoot)
  }
```

