### PR TITLE
added shadowRoot for vue-style-loader

### DIFF
--- a/src/utils/createVueInstance.js
+++ b/src/utils/createVueInstance.js
@@ -86,6 +86,7 @@ export default function createVueInstance(element, Vue, componentDefinition, pro
     if (options.shadow && element.shadowRoot) {
       element.shadowRoot.innerHTML = elementInnerHtml;
       rootElement.el = element.shadowRoot.children[0];
+      rootElement.shadowRoot = element.shadowRoot;
     } else {
       element.innerHTML = elementInnerHtml;
       rootElement.el = element.children[0];

--- a/src/utils/createVueInstance.js
+++ b/src/utils/createVueInstance.js
@@ -86,10 +86,11 @@ export default function createVueInstance(element, Vue, componentDefinition, pro
     if (options.shadow && element.shadowRoot) {
       element.shadowRoot.innerHTML = elementInnerHtml;
       rootElement.el = element.shadowRoot.children[0];
-      rootElement.shadowRoot = element.shadowRoot;
+      rootElement.shadowRoot = element.shadowRoot; //this line allows `vue-style-loader` with `shadowMode` enabled inject styles into shadow-root
     } else {
       element.innerHTML = elementInnerHtml;
       rootElement.el = element.children[0];
+      rootElement.shadowRoot = document.head; //fallback to head to append styles, if shadowDom is not supported ot disabled
     }
 
     reactiveProps(element, props);


### PR DESCRIPTION
Hi, `vue-style-loader` can inject css into shadowDom, what is missing from `vue-custom-element` is reference to this shadowDom.

this PR fixes it.

Usage:
```javascript
import Vue from 'vue';
import vueCustomElement from "vue-custom-element";

Vue.use(vueCustomElement);

Vue.customElement('test-component', () => import("./components/TestComponent").then(c => c.default), {
	shadow: true
});

//component
//
<template>
	<div class="myClass">This is red color</div>
</template>
<style lang="scss">
	.myClass{
		color: red;
	}
</style>


//Webpack
{
    test: /\.vue$/,
    use: [
        {
            loader: 'vue-loader',
            options: {
            	shadowMode: true
            }
        }
    ]
},
{
    test: /\.scss$/, //as example I used scss
    use: [
        {
            loader: 'vue-style-loader',
            options: {
                shadowMode: true
            }
        }
    ]
}
```

Fixes: #214 #191 #156 