### PR TITLE
Bugfix: prop change not updating vue instance for async component

### DIFF
--- a/src/utils/createVueInstance.js
+++ b/src/utils/createVueInstance.js
@@ -1,4 +1,4 @@
-import { getPropsData, reactiveProps } from './props';
+import { getPropsData, reactiveProps, syncProps } from './props';
 import { getSlots } from './slots';
 import { customEmit } from './customEvent';
 
@@ -103,6 +103,7 @@ export default function createVueInstance(element, Vue, componentDefinition, pro
   }
 
   reactiveProps(element, props);
+  syncProps(element, props, options);
 
   if (typeof options.beforeCreateVueInstance === 'function') {
     rootElement = options.beforeCreateVueInstance(rootElement) || rootElement;

--- a/src/vue-custom-element.js
+++ b/src/vue-custom-element.js
@@ -1,7 +1,6 @@
 import registerCustomElement from './utils/registerCustomElement';
 import createVueInstance from './utils/createVueInstance';
-import { getProps, convertAttributeValue } from './utils/props';
-import { camelize } from './utils/helpers';
+import { getProps } from './utils/props';
 
 function install(Vue) {
   Vue.customElement = function vueCustomElement(tag, componentDefinition, options = {}) {
@@ -59,23 +58,6 @@ function install(Vue) {
           }
         }, options.destroyTimeout || 3000);
       },
-
-      /**
-       * When attribute changes we should update Vue instance
-       * @param name
-       * @param oldVal
-       * @param value
-       */
-      attributeChangedCallback(name, oldValue, value) {
-        if (this.__vue_custom_element__ && typeof value !== 'undefined') {
-          const nameCamelCase = camelize(name);
-          typeof options.attributeChangedCallback === 'function' && options.attributeChangedCallback.call(this, name, oldValue, value);
-          const type = this.__vue_custom_element_props__.types[nameCamelCase];
-          this.__vue_custom_element__[nameCamelCase] = convertAttributeValue(value, type);
-        }
-      },
-
-      observedAttributes: props.hyphenate,
 
       shadow: !!options.shadow && !!HTMLElement.prototype.attachShadow
     });


### PR DESCRIPTION
For async component, props definition weren't available when setting `observedAttributes` causing `attributeChangedCallback` not firing at all.

Changing to use `MutationObserver` to watch for any attribute changes.
---
I'm not able to run `npm install` on this package somehow so not able to build this. Tested it in my own repo and it works so if someone can help to build this, it would be very appreciated.

Also, we should update doc to say we can use Async Component